### PR TITLE
bug fix for api_accounts() - reformat margin balances - logic check

### DIFF
--- a/R/api_accounts.R
+++ b/R/api_accounts.R
@@ -22,7 +22,7 @@ api_accounts <- function(RH) {
   dta <- as.list(dta$results)
 
   # Reformat margin balances
-  if (length(dta$margin_balances > 1)) {
+  if (length(dta$margin_balances) > 1) {
     dta$margin_balances <- dta$margin_balances %>%
       dplyr::mutate_at(
         c("gold_equity_requirement", "outstanding_interest", "cash_held_for_options_collateral",


### PR DESCRIPTION
logical check in the part of `api_accounts` that is supposed to reformat margin balances was buggy and lead to that part always being executed, no matter the input format, causing the whole function to fail for me. I am pretty sure this is the intended logic, please review and let me know.