### PR TITLE
adding status check to all GET and POST calls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RobinHood
 Type: Package
 Title: Interface for the RobinHood.com No Commission Investing Platform
-Version: 1.6.4
+Version: 1.6.5
 Author: Joseph Blubaugh
 Maintainer: Joseph Blubaugh <jestonblu@gmail.com>
 Description: Execute API calls to the RobinHood <https://robinhood.com> investing platform. Functionality includes accessing account data and current holdings, retrieving investment statistics and quotes, placing and canceling orders, getting market trading hours, searching investments by popular tag, and interacting with watch lists.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 title: "NEWS"
 ---
 
+# RobinHood 1.6.5
+  - [(GH-147)](https://github.com/JestonBlu/RobinHood/issues/99): Added HTTPS validation check to make cryptic errors less likely (@JanLauGe)
+
 # RobinHood 1.6.4
 
 ## Bug Fixes

--- a/R/api_accounts.R
+++ b/R/api_accounts.R
@@ -16,6 +16,7 @@ api_accounts <- function(RH) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
+  httr::stop_for_status(dta)
 
   # Format return
   dta <- RobinHood::mod_json(dta, "fromJSON")

--- a/R/api_accounts_crypto.R
+++ b/R/api_accounts_crypto.R
@@ -16,7 +16,8 @@ api_accounts_crypto <- function(RH) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.list(dta$results)

--- a/R/api_ach.R
+++ b/R/api_ach.R
@@ -23,7 +23,8 @@ api_ach <- function(RH, action, amount = NULL, status_url = NULL, cancel_url = N
                add_headers("Accept" = "application/json",
                            "Content-Type" = "application/json",
                            "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # format return
     dta <- RobinHood::mod_json(dta, "fromJSON")
     dta <- as.data.frame(dta$results)
@@ -49,7 +50,8 @@ api_ach <- function(RH, action, amount = NULL, status_url = NULL, cancel_url = N
                add_headers("Accept" = "application/json",
                            "Content-Type" = "application/json",
                            "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # format return
     dta <- RobinHood::mod_json(dta, "fromJSON")
     dta <- as.data.frame(dta$results)
@@ -76,7 +78,8 @@ api_ach <- function(RH, action, amount = NULL, status_url = NULL, cancel_url = N
                add_headers("Accept" = "application/json",
                            "Content-Type" = "application/json",
                            "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # format return
     dta <- RobinHood::mod_json(dta, "fromJSON")
     dta <- as.data.frame(dta$results)
@@ -109,7 +112,8 @@ api_ach <- function(RH, action, amount = NULL, status_url = NULL, cancel_url = N
                  rawToChar() %>%
                  jsonlite::fromJSON() %>%
                  as.list()
-
+    httr::stop_for_status(dta)
+    
     # Select elements
     dta <- list(
       status_url = dta$url,
@@ -149,6 +153,8 @@ api_ach <- function(RH, action, amount = NULL, status_url = NULL, cancel_url = N
                             "Content-Type" = "application/json",
                             "Authorization" = token)) %>%
                 mod_json("fromJSON")
+    httr::stop_for_status(dta)
+    
   }
 
 
@@ -167,7 +173,10 @@ api_ach <- function(RH, action, amount = NULL, status_url = NULL, cancel_url = N
                 add_headers("Accept" = "application/json",
                             "Content-Type" = "application/json",
                             "Authorization" = token),
-                body = mod_json(detail, "toJSON")) %>%
+                body = mod_json(detail, "toJSON"))
+    httr::stop_for_status(dta)
+    
+    dta <- dta %>%
       content(type = "json") %>%
       rawToChar() %>%
       jsonlite::fromJSON() %>%

--- a/R/api_contracts.R
+++ b/R/api_contracts.R
@@ -20,7 +20,8 @@ api_contracts <- function(RH, chain_symbol, type) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # format return
   dta <- RobinHood::mod_json(dta, "fromJSON")
   dta <- as.data.frame(dta$results)

--- a/R/api_currency_pairs.R
+++ b/R/api_currency_pairs.R
@@ -16,7 +16,8 @@ api_currency_pairs <- function(RH) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # Format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.list(dta$results)

--- a/R/api_fundamentals.R
+++ b/R/api_fundamentals.R
@@ -18,7 +18,8 @@ api_fundamentals <- function(RH, ticker) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # Format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.data.frame(dta$results)

--- a/R/api_historicals.R
+++ b/R/api_historicals.R
@@ -18,7 +18,8 @@ api_historicals <- function(RH, historicals_url, body) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # Format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.data.frame(dta$results$historicals)

--- a/R/api_historicals_crypto.R
+++ b/R/api_historicals_crypto.R
@@ -16,7 +16,8 @@ api_historicals_crypto <- function(RH, url) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # Format return
   dta <- RobinHood::mod_json(dta, "fromJSON")
   dta <- as.data.frame(dta$data_points)

--- a/R/api_historicals_options.R
+++ b/R/api_historicals_options.R
@@ -32,7 +32,8 @@ api_historicals_options <- function(RH, chain_symbol, type, strike_price, expira
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # Format return
   dta <- mod_json(dta, "fromJSON")
 

--- a/R/api_instruments.R
+++ b/R/api_instruments.R
@@ -22,7 +22,8 @@ api_instruments <- function(RH, symbol = NULL, instrument_url = NULL) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # Format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.list(dta)

--- a/R/api_instruments_options.R
+++ b/R/api_instruments_options.R
@@ -29,7 +29,8 @@ api_instruments_options <- function(RH, method = "url", option_instrument_url = 
                add_headers("Accept" = "application/json",
                            "Content-Type" = "application/json",
                            "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # Format return
     dta <- RobinHood::mod_json(dta, "fromJSON")
     dta <- as.data.frame(dta)
@@ -62,7 +63,8 @@ api_instruments_options <- function(RH, method = "url", option_instrument_url = 
                add_headers("Accept" = "application/json",
                            "Content-Type" = "application/json",
                            "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # Format return
     dta <- RobinHood::mod_json(dta, "fromJSON")
     output <- as.data.frame(dta$results)
@@ -81,7 +83,8 @@ api_instruments_options <- function(RH, method = "url", option_instrument_url = 
                  add_headers("Accept" = "application/json",
                              "Content-Type" = "application/json",
                              "Authorization" = token))
-
+      httr::stop_for_status(dta)
+      
       # Format return
       dta <- RobinHood::mod_json(dta, "fromJSON")
 

--- a/R/api_login.R
+++ b/R/api_login.R
@@ -25,7 +25,10 @@ api_login <- function(username, password, mfa_code) {
   url <- paste(api_endpoints("token"), detail, sep = "")
 
   # POST call
-  dta <- POST(url) %>%
+  dta <- POST(url)
+  httr::stop_for_status(dta)
+  
+  dta <- dta %>%
     content(type = "json") %>%
     rawToChar() %>%
     jsonlite::fromJSON() %>%
@@ -45,7 +48,10 @@ api_login <- function(username, password, mfa_code) {
   if (length(dta) == 2 & mfa_code != "000000") {
 
     # POST call
-    dta <- POST(url, body = list(mfa_code = mfa_code)) %>%
+    dta <- POST(url, body = list(mfa_code = mfa_code))
+    httr::stop_for_status(dta)
+    
+    dta <- dta %>%
       content(type = "json") %>%
       rawToChar() %>%
       jsonlite::fromJSON() %>%

--- a/R/api_logout.R
+++ b/R/api_logout.R
@@ -16,7 +16,10 @@ api_logout <- function(RH) {
   # URL
   url <- paste(api_endpoints("revoke_token"), detail, sep = "")
 
-  dta <- POST(url) %>%
+  dta <- POST(url)
+  httr::stop_for_status(dta)
+  
+  dta <- dta %>%
     content(type = "json") %>%
     rawToChar()
 

--- a/R/api_marketdata.R
+++ b/R/api_marketdata.R
@@ -23,7 +23,8 @@ api_marketdata <- function(RH, instrument, type = "instrument_id") {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # Format return
   dta <- mod_json(dta, "fromJSON")
 

--- a/R/api_markets.R
+++ b/R/api_markets.R
@@ -17,7 +17,8 @@ api_markets <- function(RH, markets_url, type = "df") {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # format return
   dta <- mod_json(dta, "fromJSON")
 

--- a/R/api_orders.R
+++ b/R/api_orders.R
@@ -53,7 +53,8 @@ api_orders <- function(RH, action, status_url = NULL, cancel_url = NULL, instrum
                             "Content-Type" = "application/json",
                             "Authorization" = token),
                 body = mod_json(detail, type = "toJSON"))
-
+    httr::stop_for_status(dta)
+    
     dta <- mod_json(dta, "fromJSON")
     dta <- as.list(dta)
 
@@ -86,7 +87,8 @@ api_orders <- function(RH, action, status_url = NULL, cancel_url = NULL, instrum
                add_headers("Accept" = "application/json",
                           "Content-Type" = "application/json",
                           "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # format return
     dta <- mod_json(dta, "fromJSON")
     dta <- as.list(dta)
@@ -107,7 +109,8 @@ api_orders <- function(RH, action, status_url = NULL, cancel_url = NULL, instrum
         add_headers("Accept" = "application/json",
                     "Content-Type" = "application/json",
                     "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # Format return
     dta <- mod_json(dta, "fromJSON")
 
@@ -124,7 +127,8 @@ api_orders <- function(RH, action, status_url = NULL, cancel_url = NULL, instrum
         add_headers("Accept" = "application/json",
                     "Content-Type" = "application/json",
                     "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # format return
     dta <- mod_json(dta, "fromJSON")
     dta <- as.data.frame(dta$results)

--- a/R/api_orders_crypto.R
+++ b/R/api_orders_crypto.R
@@ -38,7 +38,8 @@ api_orders_crypto <- function(RH, action, order_id = NULL, cancel_url = NULL, cu
                             "Content-Type" = "application/json",
                             "Authorization" = paste("Bearer", RH$tokens.access_token)),
                 body = mod_json(detail, type = "toJSON"))
-
+    httr::stop_for_status(dta)
+    
     dta <- mod_json(dta, type = "fromJSON")
 
     dta$cumulative_quantity <- as.numeric(dta$cumulative_quantity)
@@ -62,7 +63,8 @@ api_orders_crypto <- function(RH, action, order_id = NULL, cancel_url = NULL, cu
         add_headers("Accept" = "application/json",
                     "Content-Type" = "application/json",
                     "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # format return
     dta <- mod_json(dta, "fromJSON")
 
@@ -88,7 +90,8 @@ api_orders_crypto <- function(RH, action, order_id = NULL, cancel_url = NULL, cu
         add_headers("Accept" = "application/json",
                     "Content-Type" = "application/json",
                     "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # format return
     dta <- mod_json(dta, "fromJSON")
 
@@ -107,7 +110,8 @@ api_orders_crypto <- function(RH, action, order_id = NULL, cancel_url = NULL, cu
                add_headers("Accept" = "application/json",
                            "Content-Type" = "application/json",
                            "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # format return
     dta <- mod_json(dta, "fromJSON")
     output <- as.data.frame(dta$results)
@@ -123,7 +127,8 @@ api_orders_crypto <- function(RH, action, order_id = NULL, cancel_url = NULL, cu
                  add_headers("Accept" = "application/json",
                              "Content-Type" = "application/json",
                              "Authorization" = token))
-
+      httr::stop_for_status(dta)
+      
       # Format return
       dta <- mod_json(dta, "fromJSON")
 

--- a/R/api_orders_options.R
+++ b/R/api_orders_options.R
@@ -28,7 +28,8 @@ api_orders_options <- function(RH, action, status_url = NULL, cancel_url = NULL,
                add_headers("Accept" = "application/json",
                            "Content-Type" = "application/json",
                            "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # format return
     dta <- mod_json(dta, "fromJSON")
     dta <- as.data.frame(dta$results)
@@ -83,7 +84,8 @@ api_orders_options <- function(RH, action, status_url = NULL, cancel_url = NULL,
                             "Content-Type" = "application/json",
                             "Authorization" = token),
                 body = detail)
-
+    httr::stop_for_status(dta)
+    
     dta <- mod_json(dta, "fromJSON")
     dta <- as.list(dta)
 
@@ -111,6 +113,8 @@ api_orders_options <- function(RH, action, status_url = NULL, cancel_url = NULL,
                 add_headers("Accept" = "application/json",
                             "Content-Type" = "application/json",
                             "Authorization" = token))
+    httr::stop_for_status(dta)
+    
     # Format return
     dta <- mod_json(dta, "fromJSON")
 
@@ -124,7 +128,8 @@ api_orders_options <- function(RH, action, status_url = NULL, cancel_url = NULL,
                add_headers("Accept" = "application/json",
                            "Content-Type" = "application/json",
                            "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # Format return
     dta <- mod_json(dta, "fromJSON")
     dta <- as.list(dta)

--- a/R/api_portfolio_crypto.R
+++ b/R/api_portfolio_crypto.R
@@ -18,7 +18,8 @@ api_portfolios_crypto <- function(RH) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.list(dta)

--- a/R/api_portfolios.R
+++ b/R/api_portfolios.R
@@ -18,7 +18,8 @@ api_portfolios <- function(RH, portfolio_url) {
                add_headers("Accept" = "application/json",
                            "Content-Type" = "application/json",
                            "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # format return
     dta <- RobinHood::mod_json(dta, "fromJSON")
     dta <- as.data.frame(dta$results)
@@ -39,7 +40,8 @@ api_portfolios <- function(RH, portfolio_url) {
                add_headers("Accept" = "application/json",
                            "Content-Type" = "application/json",
                            "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # format return
     dta <- RobinHood::mod_json(dta, "fromJSON")
     dta <- as.data.frame(dta$equity_historicals)

--- a/R/api_positions.R
+++ b/R/api_positions.R
@@ -16,7 +16,8 @@ api_positions <- function(RH) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # Format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.data.frame(dta$results)

--- a/R/api_positions_crypto.R
+++ b/R/api_positions_crypto.R
@@ -16,7 +16,8 @@ api_positions_crypto <- function(RH) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.list(dta$results)

--- a/R/api_positions_options.R
+++ b/R/api_positions_options.R
@@ -16,7 +16,8 @@ api_positions_options <- function(RH) { # nolint
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # format return
   dta <- RobinHood::mod_json(dta, "fromJSON")
   dta <- as.data.frame(dta$results)

--- a/R/api_quote.R
+++ b/R/api_quote.R
@@ -17,7 +17,8 @@ api_quote <- function(RH, symbols_url) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.data.frame(dta$results)

--- a/R/api_quote_crypto.R
+++ b/R/api_quote_crypto.R
@@ -17,7 +17,8 @@ api_quote_crypto <- function(RH, symbols_url) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.data.frame(dta)

--- a/R/api_ratings.R
+++ b/R/api_ratings.R
@@ -17,7 +17,8 @@ api_ratings <- function(RH, symbol) {
 
   # GET call
   dta <- GET(url, add_headers("Accept" = "application/json", "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.list(dta$results)

--- a/R/api_tag.R
+++ b/R/api_tag.R
@@ -17,7 +17,8 @@ api_tag <- function(RH, tag) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.character(dta$instruments)

--- a/R/api_tickers.R
+++ b/R/api_tickers.R
@@ -22,7 +22,8 @@ api_tickers <- function(RH) {
              add_headers("Accept" = "application/json",
                          "Content-Type" = "application/json",
                          "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # Format return
   dta <- mod_json(dta, "fromJSON")
 
@@ -39,7 +40,8 @@ api_tickers <- function(RH) {
                add_headers("Accept" = "application/json",
                            "Content-Type" = "application/json",
                            "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     # Format return
     dta <- mod_json(dta, "fromJSON")
 

--- a/R/api_user.R
+++ b/R/api_user.R
@@ -13,7 +13,8 @@ api_user <- function(RH) {
 
   # GET call
   dta <- GET(url, add_headers("Accept" = "application/json", "Authorization" = token))
-
+  httr::stop_for_status(dta)
+  
   # format return
   dta <- mod_json(dta, "fromJSON")
   dta <- as.list(dta)

--- a/R/api_watchlist.R
+++ b/R/api_watchlist.R
@@ -29,7 +29,8 @@ api_watchlist <- function(RH, watchlist_url, detail = FALSE, delete = FALSE) {
                            "Content-Type" = "application/json",
                            "Authorization" = token),
                config(customrequest = "DELETE"))
-
+    httr::stop_for_status(dta)
+    
     dta <- rawToChar(dta$content)
 
   }
@@ -42,7 +43,8 @@ api_watchlist <- function(RH, watchlist_url, detail = FALSE, delete = FALSE) {
                add_headers("Accept" = "application/json",
                            "Content-Type" = "application/json",
                            "Authorization" = token))
-
+    httr::stop_for_status(dta)
+    
     dta <- mod_json(dta, "fromJSON")
 
   }
@@ -56,6 +58,8 @@ api_watchlist <- function(RH, watchlist_url, detail = FALSE, delete = FALSE) {
                             "Content-Type" = "application/json",
                             "Authorization" = token),
                 body = mod_json(detail, "toJSON"))
+    httr::stop_for_status(dta)
+    
 
     dta <- mod_json(dta, "fromJSON")
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Project Status](https://www.repostatus.org/badges/latest/active.svg) &nbsp;
 ![Travis-CI](https://travis-ci.org/JestonBlu/RobinHood.svg?branch=master) &nbsp;
 ![pkgdown](https://github.com/JestonBlu/RobinHood/workflows/pkgdown/badge.svg?branch=master) &nbsp;
-![Dev Version](https://img.shields.io/badge/github-1.6.4-blue.svg) &nbsp;
+![Dev Version](https://img.shields.io/badge/github-1.6.5-blue.svg) &nbsp;
 ![CRAN Version](http://www.r-pkg.org/badges/version/RobinHood?color=blue) &nbsp;
 ![CRAN Downloads](http://cranlogs.r-pkg.org/badges/grand-total/RobinHood) &nbsp;
 

--- a/renv.lock
+++ b/renv.lock
@@ -749,10 +749,10 @@
     },
     "reshape": {
       "Package": "reshape",
-      "Version": "0.8.8",
+      "Version": "0.8.9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0f4d941129e00ed34a7d192b1da7ccef",
+      "Hash": "603d56041d7d4fa3ceb1864b3f6ee6b1",
       "Requirements": [
         "plyr"
       ]
@@ -808,10 +808,10 @@
     },
     "scales": {
       "Package": "scales",
-      "Version": "1.1.1",
+      "Version": "1.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6f76f71042411426ec8df6c54f34e6dd",
+      "Hash": "6e8750cdd13477aa440d453da93d5cac",
       "Requirements": [
         "R6",
         "RColorBrewer",
@@ -819,6 +819,7 @@
         "labeling",
         "lifecycle",
         "munsell",
+        "rlang",
         "viridisLite"
       ]
     },
@@ -971,10 +972,10 @@
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.4.0",
+      "Version": "0.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "95c2573b232eac82df562f9e300f9790",
+      "Hash": "8b54f22e2a58c4f275479c92ce041a57",
       "Requirements": [
         "cli",
         "glue",


### PR DESCRIPTION
Hey @JestonBlu 

Thank you for spotting the bug in my earlier PR!
Here is an updated version. Note that I also split a couple of pipes to add `stop_for_status()` to `POST()` calls, e.g. in `api_logout.R`